### PR TITLE
chore(ci): workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,8 @@
 # It will need to be changed to match the requirements
 # of your repo.
 name: CI Pipeline
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Bay-Shore-Systems-Inc/cache/security/code-scanning/2](https://github.com/Bay-Shore-Systems-Inc/cache/security/code-scanning/2)

To remediate, explicitly set the minimal required permissions for the workflow in the YAML. All jobs in this workflow just checkout and build/test code, and upload summaries, none of which require write permissions to repository contents, so we can safely set `contents: read` at the workflow root, placing a `permissions:` block below the `name:` field (above `on:`). This change limits the GITHUB_TOKEN to read-only operations on repository contents, following least privilege. Edit `.github/workflows/ci.yaml` and insert:

```yaml
permissions:
  contents: read
```

right after the workflow `name:` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
