### PR TITLE
chore(ci): workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -1,4 +1,6 @@
 name: Validate PR Title
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Bay-Shore-Systems-Inc/cache/security/code-scanning/1](https://github.com/Bay-Shore-Systems-Inc/cache/security/code-scanning/1)

To fix this problem, we should explicitly declare a `permissions` block for this job or the workflow root. Reviewing the workflow, it only runs a third-party action to lint pull request titles, does not write to the repo, or trigger actions via API, so "read" access to `contents` should suffice. Optionally, if some annotation features or status reporting are used, additional scopes (like `pull-requests: write` or `statuses: write`) could be added, but the minimal safe default is just `contents: read`. The fix is to add:
```yaml
permissions:
  contents: read
```
either at the top-level, or inside the `lint-title` job. The preferred location (as per CodeQL suggestion and conventional usage) is at the workflow root, allowing all jobs to inherit it unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
